### PR TITLE
Panic and leak the stack if it's unsafe to drop it

### DIFF
--- a/benches/generator.rs
+++ b/benches/generator.rs
@@ -8,7 +8,6 @@
 extern crate test;
 extern crate fringe;
 
-use std::mem;
 use fringe::{OsStack, Generator};
 
 #[bench]
@@ -19,5 +18,5 @@ fn generate(b: &mut test::Bencher) {
   });
 
   b.iter(|| for _ in 0..10 { test::black_box(identity.resume(test::black_box(0))); });
-  mem::forget(identity);
+  unsafe { identity.unsafe_unwrap(); }
 }

--- a/benches/generator.rs
+++ b/benches/generator.rs
@@ -8,6 +8,7 @@
 extern crate test;
 extern crate fringe;
 
+use std::mem;
 use fringe::{OsStack, Generator};
 
 #[bench]
@@ -18,4 +19,5 @@ fn generate(b: &mut test::Bencher) {
   });
 
   b.iter(|| for _ in 0..10 { test::black_box(identity.resume(test::black_box(0))); });
+  mem::forget(identity);
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -201,7 +201,9 @@ impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
     }
   }
 
-  unsafe fn unsafe_unwrap(mut self) -> Stack {
+  /// Extracts the stack from a generator without checking if the generator function has returned.
+  /// This will leave any pointers into the generator stack dangling, and won't run destructors.
+  pub unsafe fn unsafe_unwrap(mut self) -> Stack {
     ptr::drop_in_place(&mut self.stack_id.value);
     let stack = ptr::read(&mut self.stack.value);
     mem::forget(self);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -111,7 +111,7 @@ impl<'a, Input, Output, Stack> Generator<'a, Input, Output, Stack>
   ///
   /// See also the [contract](../trait.GuardedStack.html) that needs to be fulfilled by `stack`.
   pub fn new<F>(stack: Stack, f: F) -> Generator<'a, Input, Output, Stack>
-      where Stack: stack::GuardedStack,
+      where Stack: stack::GuardedStack + 'static,
             F: FnOnce(&Yielder<Input, Output>, Input) + 'a {
     unsafe { Generator::unsafe_new(stack, f) }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(asm, naked_functions, cfg_target_vendor)]
+#![feature(asm, naked_functions, cfg_target_vendor, untagged_unions)]
 #![cfg_attr(feature = "alloc", feature(alloc, heap_api))]
 #![cfg_attr(test, feature(test))]
 #![no_std]

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -73,6 +73,7 @@ fn with_slice_stack() {
   let mut add_one = unsafe { Generator::unsafe_new(stack, add_one_fn) };
   assert_eq!(add_one.resume(1), Some(2));
   assert_eq!(add_one.resume(2), Some(3));
+  assert_eq!(add_one.resume(0), None);
 }
 
 #[test]
@@ -81,6 +82,7 @@ fn with_owned_stack() {
   let mut add_one = unsafe { Generator::unsafe_new(stack, add_one_fn) };
   assert_eq!(add_one.resume(1), Some(2));
   assert_eq!(add_one.resume(2), Some(3));
+  assert_eq!(add_one.resume(0), None);
 }
 
 #[test]

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -8,6 +8,7 @@ extern crate fringe;
 
 use fringe::OsStack;
 use fringe::generator::Generator;
+use std::mem;
 
 #[test]
 fn producer() {
@@ -18,4 +19,5 @@ fn producer() {
   assert_eq!(gen.next(), Some(0));
   assert_eq!(gen.next(), Some(1));
   assert_eq!(gen.next(), Some(2));
+  mem::forget(gen);
 }

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -8,7 +8,6 @@ extern crate fringe;
 
 use fringe::OsStack;
 use fringe::generator::Generator;
-use std::mem;
 
 #[test]
 fn producer() {
@@ -19,5 +18,5 @@ fn producer() {
   assert_eq!(gen.next(), Some(0));
   assert_eq!(gen.next(), Some(1));
   assert_eq!(gen.next(), Some(2));
-  mem::forget(gen);
+  unsafe { gen.unsafe_unwrap(); }
 }


### PR DESCRIPTION
We can't free the stack before the generator has returned, or been unwound. Without unwinding, the only safe course of action is to leak it.

We could additionally panic, since users can `mem::forget` the generator if they do intend to leak. Leaking in the destructor is not avoidable even if we panic, since we can't free the stack.