### PR TITLE
Update alloc usage to support latest nightly; work around check in llvm that broke x86

### DIFF
--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -208,7 +208,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
         # to avoid return address mispredictions (~8ns per `ret` on Ivy Bridge).
         popl    %eax
         .cfi_adjust_cfa_offset -4
-        .cfi_register %eip, %eax
+        .cfi_register 8, %eax
         jmpl    *%eax
       "#
       : : : : "volatile")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 #![feature(asm, naked_functions, cfg_target_vendor, untagged_unions)]
-#![cfg_attr(feature = "alloc", feature(alloc, heap_api, allocator_api))]
+#![cfg_attr(feature = "alloc", feature(alloc, allocator_api))]
 #![cfg_attr(test, feature(test))]
 #![no_std]
 

--- a/src/stack/owned_stack.rs
+++ b/src/stack/owned_stack.rs
@@ -4,8 +4,8 @@
 extern crate alloc;
 
 use core::slice;
-use self::alloc::heap::Global;
-use self::alloc::allocator::{Alloc, Layout};
+use self::alloc::alloc::Global;
+use self::alloc::alloc::{Alloc, Layout};
 use self::alloc::boxed::Box;
 use stack::Stack;
 

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(alloc, heap_api, allocator_api)]
+#![feature(alloc, allocator_api)]
 
 extern crate alloc;
 extern crate fringe;

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -9,8 +9,8 @@
 extern crate alloc;
 extern crate fringe;
 
-use alloc::heap::Global;
-use alloc::allocator::{Alloc, Layout};
+use alloc::alloc::Global;
+use alloc::alloc::{Alloc, Layout};
 use alloc::boxed::Box;
 use std::slice;
 use fringe::{STACK_ALIGNMENT, Stack, SliceStack, OwnedStack, OsStack};


### PR DESCRIPTION
%eip => 8 just avoids a check LLVM was making during parsing that balked with "register %eip is only available in 64-bit mode": https://github.com/llvm-mirror/llvm/blob/7ead4232dac43866b3aa2b39aa787823654f4f36/lib/Target/X86/AsmParser/X86AsmParser.cpp#L1102