### PR TITLE
Switch to llvm_asm to compile on latest nightly.

### DIFF
--- a/benches/syscall.rs
+++ b/benches/syscall.rs
@@ -12,7 +12,7 @@ extern crate test;
 #[bench]
 fn syscall(b: &mut test::Bencher) {
   b.iter(|| unsafe {
-    asm!("movq $$102, %rax\n\
+    llvm_asm!("movq $$102, %rax\n\
           syscall"
          :
          :
@@ -25,7 +25,7 @@ fn syscall(b: &mut test::Bencher) {
 #[bench]
 fn syscall(b: &mut test::Bencher) {
   b.iter(|| unsafe {
-    asm!("mov $$24, %eax\n\
+    llvm_asm!("mov $$24, %eax\n\
           int $$0x80"
          :
          :

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -59,7 +59,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
         # gdb has a hardcoded check that rejects backtraces where frame addresses
         # do not monotonically decrease. It is turned off if the function is called
@@ -95,7 +95,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(target_vendor = "apple")]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
       # Identical to the above, except avoids .local/.size that aren't available on Mach-O.
       __morestack:
@@ -110,7 +110,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
 
   #[naked]
   unsafe extern "C" fn trampoline_2() {
-    asm!(
+    llvm_asm!(
       r#"
         # Set up the second part of our DWARF CFI.
         # When unwinding the frame corresponding to this function, a DWARF unwinder
@@ -180,7 +180,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   let ret: usize;
   let ret_sp: *mut usize;
-  asm!(
+  llvm_asm!(
     r#"
         # Set up the link register
         adr     lr, 0f

--- a/src/arch/or1k.rs
+++ b/src/arch/or1k.rs
@@ -53,7 +53,7 @@ pub struct StackPointer(*mut usize);
 pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -> !) -> StackPointer {
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
         # gdb has a hardcoded check that rejects backtraces where frame addresses
         # do not monotonically decrease. It is turned off if the function is called
@@ -88,7 +88,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
 
   #[naked]
   unsafe extern "C" fn trampoline_2() {
-    asm!(
+    llvm_asm!(
       r#"
         # Set up the second part of our DWARF CFI.
         # When unwinding the frame corresponding to this function, a DWARF unwinder
@@ -160,7 +160,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   #[naked]
   unsafe extern "C" fn trampoline() {
-    asm!(
+    llvm_asm!(
       r#"
         # Save the frame pointer and link register; the unwinder uses them to find
         # the CFA of the caller, and so they have to have the correct value immediately
@@ -194,7 +194,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   let ret: usize;
   let ret_sp: *mut usize;
-  asm!(
+  llvm_asm!(
     r#"
       # Call the trampoline to switch to the new context.
       l.jal   ${2}

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -54,7 +54,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
         # gdb has a hardcoded check that rejects backtraces where frame addresses
         # do not monotonically decrease. It is turned off if the function is called
@@ -94,7 +94,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(target_vendor = "apple")]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
       # Identical to the above, except avoids .local/.size that aren't available on Mach-O.
       __morestack:
@@ -109,7 +109,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
 
   #[naked]
   unsafe extern "C" fn trampoline_2() {
-    asm!(
+    llvm_asm!(
       r#"
         # Set up the second part of our DWARF CFI.
         # When unwinding the frame corresponding to this function, a DWARF unwinder
@@ -182,7 +182,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   #[naked]
   unsafe extern "C" fn trampoline() {
-    asm!(
+    llvm_asm!(
       r#"
         # Save frame pointer explicitly; the unwinder uses it to find CFA of
         # the caller, and so it has to have the correct value immediately after
@@ -217,7 +217,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   let ret: usize;
   let ret_sp: *mut usize;
-  asm!(
+  llvm_asm!(
     r#"
       # Push instruction pointer of the old context and switch to
       # the new context.

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -59,7 +59,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(not(target_vendor = "apple"))]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
         # gdb has a hardcoded check that rejects backtraces where frame addresses
         # do not monotonically decrease. It is turned off if the function is called
@@ -99,7 +99,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
   #[cfg(target_vendor = "apple")]
   #[naked]
   unsafe extern "C" fn trampoline_1() {
-    asm!(
+    llvm_asm!(
       r#"
       # Identical to the above, except avoids .local/.size that aren't available on Mach-O.
       __morestack:
@@ -114,7 +114,7 @@ pub unsafe fn init(stack: &Stack, f: unsafe extern "C" fn(usize, StackPointer) -
 
   #[naked]
   unsafe extern "C" fn trampoline_2() {
-    asm!(
+    llvm_asm!(
       r#"
         # Set up the second part of our DWARF CFI.
         # When unwinding the frame corresponding to this function, a DWARF unwinder
@@ -182,7 +182,7 @@ pub unsafe fn swap(arg: usize, new_sp: StackPointer,
 
   let ret: usize;
   let ret_sp: *mut usize;
-  asm!(
+  llvm_asm!(
     r#"
         # Push the return address
         leaq    0f(%rip), %rax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-#![feature(asm, naked_functions, untagged_unions)]
+#![feature(llvm_asm, naked_functions, untagged_unions)]
 #![cfg_attr(feature = "alloc", feature(alloc, allocator_api))]
 #![cfg_attr(test, feature(test))]
 #![no_std]

--- a/src/stack/os/sys.rs
+++ b/src/stack/os/sys.rs
@@ -17,13 +17,13 @@ use self::libc::MAP_FAILED;
 const GUARD_PROT:  c_int = libc::PROT_NONE;
 const STACK_PROT:  c_int = libc::PROT_READ
                          | libc::PROT_WRITE;
-#[cfg(not(any(target_os = "freebsd", target_os = "dragonfly", target_vendor = "apple")))]
+#[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "dragonfly", target_vendor = "apple")))]
 const STACK_FLAGS: c_int = libc::MAP_STACK
                          | libc::MAP_PRIVATE
                          | libc::MAP_ANON;
 // workaround for http://lists.freebsd.org/pipermail/freebsd-bugs/2011-July/044840.html
 // according to libgreen, DragonFlyBSD suffers from this too
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_vendor = "apple"))]
+#[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "dragonfly", target_vendor = "apple"))]
 const STACK_FLAGS: c_int = libc::MAP_PRIVATE
                          | libc::MAP_ANON;
 


### PR DESCRIPTION
Note that this also needs https://github.com/edef1c/libvalgrind_request/pull/4 to be merged and a new version for libvalgrind_request.