### PR TITLE
fix cargo config file for using no extra features

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To use libfringe on a bare-metal target, add the `no-default-features` key:
 ```toml
 [dependencies.fringe]
 version = "1.2.1"
-no-default-features = true
+default-features = false
 ```
 
 ### Feature flags


### PR DESCRIPTION
on my computer + in the doc 
https://doc.rust-lang.org/cargo/reference/features.html

`default-features = false` is the way to disable extra features

(I think `no-default-features` is for command line invocation)